### PR TITLE
Remove serialize println

### DIFF
--- a/src/serde/serialize.rs
+++ b/src/serde/serialize.rs
@@ -208,7 +208,6 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
-        println!("Start Serializing struct: {name}\n");
         self.output += "{ ";
         Ok(self)
     }


### PR DESCRIPTION
I'm using the crate in a cli tool and I was wondering if this print could be removed.